### PR TITLE
Check that we can allocate a memory object.

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -1,6 +1,12 @@
 use alienfile;
 use Path::Tiny qw( path );
+use File::Which qw( which );
 use Config;
+
+configure {
+  requires 'Path::Tiny';
+  requires 'File::Which';
+};
 
 if($^O eq 'linux')
 {
@@ -11,6 +17,43 @@ if($^O eq 'linux')
     print "If we are missing a binary tarball that could work for your platform, please comment here:\n";
     print "https://github.com/perlwasm/Alien-wasmtime/issues/2\n";
     exit;
+  }
+
+  if(which 'bash')
+  {
+    # call ulimit via bash in case
+    # the user's shell is not bash.
+    my($vm) = grep /virtual memory/, `bash -c 'ulimit -a'`;
+    if(defined $vm)
+    {
+      chomp $vm;
+      if($vm !~ /unlimited/)
+      {
+        log " !! WARNING !! WARNING !!";
+        log " !! WARNING !! WARNING !!";
+        log " ";
+        log " ";
+        log "You seem to have a virtual address limit set.  This can cause";
+        log "problems with software like Wasmtime which use `PROT_NONE` pages";
+        log "for memory OOB checks or allocation";
+        log "Please see";
+        log "https://github.com/perlwasm/Wasm/issues/22";
+        log " ";
+        log " ";
+        log " !! WARNING !! WARNING !!";
+        log " !! WARNING !! WARNING !!";
+      }
+    }
+    else
+    {
+      log "unable to find virtual memory limit";
+      log "https://github.com/perlwasm/Wasm/issues/22";
+    }
+  }
+  else
+  {
+    log "unable to find bash, not checking virtual memory limits";
+    log "https://github.com/perlwasm/Wasm/issues/22";
   }
 }
 elsif($^O eq 'MSWin32')
@@ -40,8 +83,6 @@ else
   print "https://github.com/perlwasm/Alien-wasmtime/issues/2\n";
   exit;
 }
-
-configure { requires 'Path::Tiny' };
 
 probe sub { 'share' };
 

--- a/alienfile
+++ b/alienfile
@@ -1,11 +1,9 @@
 use alienfile;
 use Path::Tiny qw( path );
-use File::Which qw( which );
 use Config;
 
 configure {
   requires 'Path::Tiny';
-  requires 'File::Which';
 };
 
 if($^O eq 'linux')
@@ -17,43 +15,6 @@ if($^O eq 'linux')
     print "If we are missing a binary tarball that could work for your platform, please comment here:\n";
     print "https://github.com/perlwasm/Alien-wasmtime/issues/2\n";
     exit;
-  }
-
-  if(which 'bash')
-  {
-    # call ulimit via bash in case
-    # the user's shell is not bash.
-    my($vm) = grep /virtual memory/, `bash -c 'ulimit -a'`;
-    if(defined $vm)
-    {
-      chomp $vm;
-      if($vm !~ /unlimited/)
-      {
-        log " !! WARNING !! WARNING !!";
-        log " !! WARNING !! WARNING !!";
-        log " ";
-        log " ";
-        log "You seem to have a virtual address limit set.  This can cause";
-        log "problems with software like Wasmtime which use `PROT_NONE` pages";
-        log "for memory OOB checks or allocation";
-        log "Please see";
-        log "https://github.com/perlwasm/Wasm/issues/22";
-        log " ";
-        log " ";
-        log " !! WARNING !! WARNING !!";
-        log " !! WARNING !! WARNING !!";
-      }
-    }
-    else
-    {
-      log "unable to find virtual memory limit";
-      log "https://github.com/perlwasm/Wasm/issues/22";
-    }
-  }
-  else
-  {
-    log "unable to find bash, not checking virtual memory limits";
-    log "https://github.com/perlwasm/Wasm/issues/22";
   }
 }
 elsif($^O eq 'MSWin32')

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -16,6 +16,7 @@ $modules{$_} = $_ for qw(
   Alien::Build::Plugin::Build::Copy
   ExtUtils::MakeMaker
   FFI::Platypus
+  File::Which
   Path::Tiny
   Test2::V0
   Test::Alien

--- a/t/alien_wasmtime.t
+++ b/t/alien_wasmtime.t
@@ -20,6 +20,22 @@ ffi_ok
     my $engine = $ffi->function( wasm_engine_new => [] => 'opaque' )->call;
     ok $engine;
     note "engine = $engine";
+
+    my $store = $ffi->function( wasm_store_new => ['opaque'] => 'opaque' )->call($engine);
+    ok $store;
+    note "store = $store";
+
+    my $memorytype = $ffi->function( wasm_memorytype_new => ['uint32[2]'] => 'opaque' )->call([1,2]);
+    ok $memorytype;
+    note "memorytype = $memorytype";
+
+    my $memory = $ffi->function( wasm_memory_new => ['opaque','opaque'] => 'opaque' )->call($store, $memorytype);
+    ok $memory;
+    note "memory = $memory";
+
+    $ffi->function( wasm_memory_delete => ['opaque'] => 'void' )->call($memory);
+    $ffi->function( wasm_memorytype_delete => ['opaque'] => 'void' )->call($memorytype);
+    $ffi->function( wasm_store_delete => ['opaque'] => 'void' )->call($store);
     $ffi->function( wasm_engine_delete => ['opaque'] => 'void' )->call($engine);
     ok 1;
   }

--- a/t/alien_wasmtime.t
+++ b/t/alien_wasmtime.t
@@ -2,7 +2,49 @@ use Test2::V0 -no_srand => 1;
 use FFI::Platypus 1.00;
 use Test::Alien 1.90;
 use Test::Alien::Diag;
+use File::Which qw( which );
 use Alien::wasmtime;
+
+if($^O eq 'linux')
+{
+  if(which 'bash')
+  {
+    # call ulimit via bash in case
+    # the user's shell is not bash.
+    my($vm) = grep /virtual memory/, `bash -c 'ulimit -a'`;
+    if(defined $vm)
+    {
+      chomp $vm;
+      if($vm !~ /unlimited/)
+      {
+        diag " !! WARNING !! WARNING !!";
+        diag " !! WARNING !! WARNING !!";
+        diag " ";
+        diag " ";
+        diag "You seem to have a virtual address limit set.  This can cause";
+        diag "problems with software like Wasmtime which use `PROT_NONE` pages";
+        diag "for memory OOB checks or allocation";
+        diag "Please see";
+        diag "https://github.com/perlwasm/Wasm/issues/22";
+        diag " ";
+        diag " ";
+        diag " !! WARNING !! WARNING !!";
+        diag " !! WARNING !! WARNING !!";
+      }
+    }
+    else
+    {
+      diag "unable to find virtual memory limit";
+      diag "https://github.com/perlwasm/Wasm/issues/22";
+    }
+  }
+  else
+  {
+    diag "unable to find bash, not checking virtual memory limits";
+    diag "https://github.com/perlwasm/Wasm/issues/22";
+  }
+}
+
 
 alien_ok 'Alien::wasmtime';
 alien_diag 'Alien::wasmtime';


### PR DESCRIPTION
This will typically fail with a virtual memory limit on Linux because the Linux kernel `ulimit -v` limits virtual address size, including `PROT_NONE` pages that do not consume resources (at least, not the way Wasmtime is using them).  Since such a configuration renders Wasm::Wasmtime unusable, we want to catch it here.

https://github.com/perlwasm/Wasm/issues/22